### PR TITLE
docs: Fix installation doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Install 
 ```bash
-    node build.js bin/**/*.jsx
+    node build.js
 ```
 And then
 ```bash


### PR DESCRIPTION
It seems that the build.js does not take any argument so the command can be simplified.

